### PR TITLE
Build esp32 in actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+
+# vhdl:
+# roms:
+  esp32:
+    runs-on: ubuntu-latest
+    container:
+      image: espressif/idf:release-v4.2
+
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - name: Checkout the code
+      uses: actions/checkout@v2
+
+    - name: Build esp32 host-mode firmware
+      run: |
+        apt-get update
+        apt-get install -y libglib2.0-dev
+        . $IDF_PATH/export.sh
+        make -C esp32/host


### PR DESCRIPTION
Use [GitHub Actions](https://github.com/features/actions) for CI.

This is free for Open Source projects and can be used to verify that each commit/PR builds ok. Also it serves as a blueprint for for what dependencies/prerequisites are necessary to build the project.